### PR TITLE
Fix a case that `SearchIndex` objects not created because of nil anchor. (#5)

### DIFF
--- a/BoltServices/Sources/Docsets/Sources/Internal/Internal/DocsetIndexer.swift
+++ b/BoltServices/Sources/Docsets/Sources/Internal/Internal/DocsetIndexer.swift
@@ -49,12 +49,16 @@ struct DocsetIndexer: LoggerProvider {
       guard
         let name = name,
         let type = type,
-        let path = path,
-        let anchor = anchor
+        let path = path
       else {
         return nil
       }
-      let newPath = "\(path)#\(anchor)"
+      let newPath: String
+      if let anchor = anchor {
+        newPath = "\(path)#\(anchor)"
+      } else {
+        newPath = path
+      }
       return SearchIndex(id: nil, name: name, type: type, path: newPath)
     }
 


### PR DESCRIPTION
This is a temporary fix. We should carefully revisit the indexing process later.