### PR TITLE
Normalize namings of LocalFileSystem extensions.

### DIFF
--- a/BoltFramework/BoltPreferencesUI/CacheCleaner.swift
+++ b/BoltFramework/BoltPreferencesUI/CacheCleaner.swift
@@ -33,9 +33,9 @@ struct CacheCleaner: LoggerProvider {
 
   static func removeAllFiles(completionHandler: (() -> Void)?) {
     let directoriesToClear = [
-      LocalFileSystem.documentsAbsolutePath,
-      LocalFileSystem.libraryAbsolutePath,
-      LocalFileSystem.tempAbsolutePath,
+      LocalFileSystem.applicationDocumentsAbsolutePath,
+      LocalFileSystem.applicationLibraryAbsolutePath,
+      LocalFileSystem.applicationTempAbsolutePath,
     ]
     directoriesToClear.forEach { directory in
       if let files = try? FileManager.default.contentsOfDirectory(atPath: directory) {

--- a/BoltFramework/BoltPreferencesUI/CacheCleaner.swift
+++ b/BoltFramework/BoltPreferencesUI/CacheCleaner.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2023 Bolt Contributors
+// Copyright (C) 2024 Bolt Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import BoltUtils
 struct CacheCleaner: LoggerProvider {
 
   static func clearCache() async {
-    try? FileManager.default.removeItem(atPath: LocalFileSystem.downloadAbsolutePath)
+    try? FileManager.default.removeItem(atPath: LocalFileSystem.downloadsAbsolutePath)
     await Container.shared.downloadManager().clearCache()
     await AF.session.stopAllTasks()
     await AF.session.reset()
@@ -35,7 +35,7 @@ struct CacheCleaner: LoggerProvider {
     let directoriesToClear = [
       LocalFileSystem.documentsAbsolutePath,
       LocalFileSystem.libraryAbsolutePath,
-      LocalFileSystem.tmpAbsolutePath,
+      LocalFileSystem.tempAbsolutePath,
     ]
     directoriesToClear.forEach { directory in
       if let files = try? FileManager.default.contentsOfDirectory(atPath: directory) {

--- a/BoltServices/Sources/Database/Library/LibraryDatabase.swift
+++ b/BoltServices/Sources/Database/Library/LibraryDatabase.swift
@@ -41,7 +41,7 @@ public final class LibraryDatabase: LoggerProvider {
       if RuntimeEnvironment.isRunningTests {
         path = NSTemporaryDirectory().appendingPathComponent("bolt-library-\(UUID().uuidString).db")
       } else {
-        path = LocalFileSystem.libraryDatabaseAbsolutePathURL.absoluteString
+        path = LocalFileSystem.libraryDatabaseURL.absoluteString
       }
       dbPool = try DatabasePool(
         path: path,

--- a/BoltServices/Sources/Database/LocalFileSystem+Databases.swift
+++ b/BoltServices/Sources/Database/LocalFileSystem+Databases.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2023 Bolt Contributors
+// Copyright (C) 2024 Bolt Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import BoltUtils
 
 extension LocalFileSystem {
 
-  static var libraryDatabaseAbsolutePathURL: URL {
+  static var libraryDatabaseURL: URL {
     return URL(fileURLWithPath: libraryAbsolutePath).appendingPathComponent("bolt-library.db")
   }
 

--- a/BoltServices/Sources/Database/LocalFileSystem+Databases.swift
+++ b/BoltServices/Sources/Database/LocalFileSystem+Databases.swift
@@ -16,12 +16,13 @@
 
 import Foundation
 
+import BoltTypes
 import BoltUtils
 
 extension LocalFileSystem {
 
   static var libraryDatabaseURL: URL {
-    return URL(fileURLWithPath: libraryAbsolutePath).appendingPathComponent("bolt-library.db")
+    return URL(fileURLWithPath: applicationLibraryAbsolutePath).appendingPathComponent("bolt-library.db")
   }
 
 }

--- a/BoltServices/Sources/Docsets/Sources/DocsetsModule.swift
+++ b/BoltServices/Sources/Docsets/Sources/DocsetsModule.swift
@@ -18,6 +18,7 @@ import Foundation
 
 import Factory
 
+import BoltTypes
 import BoltUtils
 
 package struct DocsetsModule {
@@ -31,7 +32,7 @@ package struct DocsetsModule {
   }()
 
   private static func setupLocalStorage() {
-    logger.info("Library path: \(LocalFileSystem.libraryAbsolutePath)")
+    logger.info("Library path: \(LocalFileSystem.applicationLibraryAbsolutePath)")
     LibraryDocsetsFileSystemBridge.setupDocsetsDirectory()
   }
 

--- a/BoltServices/Sources/Docsets/Sources/Internal/Shared/LibraryDocsetsFileSystemBridge.swift
+++ b/BoltServices/Sources/Docsets/Sources/Internal/Shared/LibraryDocsetsFileSystemBridge.swift
@@ -32,7 +32,7 @@ package struct LibraryDocsetsFileSystemBridge: LoggerProvider {
   package static func setupDocsetsDirectory() {
     let fileManager = FileManager.default
     let path = LocalFileSystem.docsetsAbsolutePath
-    let url = LocalFileSystem.docsetsAbsolutePathURL
+    let url = LocalFileSystem.docsetsURL
     var requireSetup = false
 
     let (exists, isDirectory) = fileManager.fileExistsAndIsDirectory(atPath: path)

--- a/BoltServices/Sources/Docsets/Sources/LocalFileSystem.swift
+++ b/BoltServices/Sources/Docsets/Sources/LocalFileSystem.swift
@@ -26,7 +26,7 @@ public extension LocalFileSystem {
   }
 
   static var docsetsAbsolutePath: String {
-    return libraryAbsolutePath.appendingPathComponent("Docsets")
+    return applicationLibraryAbsolutePath.appendingPathComponent("Docsets")
   }
 
   static var downloadsURL: URL {
@@ -34,7 +34,7 @@ public extension LocalFileSystem {
   }
 
   static var downloadsAbsolutePath: String {
-    return cachesAbsolutePath.appendingPathComponent("Docsets").appendingPathComponent("Temp")
+    return applicationCachesAbsolutePath.appendingPathComponent("Docsets").appendingPathComponent("Temp")
   }
 
 }

--- a/BoltServices/Sources/Docsets/Sources/LocalFileSystem.swift
+++ b/BoltServices/Sources/Docsets/Sources/LocalFileSystem.swift
@@ -21,15 +21,19 @@ import BoltUtils
 
 public extension LocalFileSystem {
 
-  static var docsetsAbsolutePathURL: URL {
-    return URL(fileURLWithPath: libraryAbsolutePath).appendingPathComponent("Docsets")
+  static var docsetsURL: URL {
+    return URL(fileURLWithPath: docsetsAbsolutePath)
   }
 
   static var docsetsAbsolutePath: String {
     return libraryAbsolutePath.appendingPathComponent("Docsets")
   }
 
-  static var downloadAbsolutePath: String {
+  static var downloadsURL: URL {
+    return URL(fileURLWithPath: downloadsAbsolutePath)
+  }
+
+  static var downloadsAbsolutePath: String {
     return cachesAbsolutePath.appendingPathComponent("Docsets").appendingPathComponent("Temp")
   }
 
@@ -42,7 +46,7 @@ public extension FeedEntry {
   }
 
   static func downloadAbsolutePath(forId id: String, withExtension pathExtension: String) -> String {
-    return LocalFileSystem.downloadAbsolutePath
+    return LocalFileSystem.downloadsAbsolutePath
       .appendingPathComponent("\(id).\(pathExtension)")
   }
 

--- a/BoltServices/Sources/Docsets/Tests/Internal/Internal/BackgroundDownloderTests.swift
+++ b/BoltServices/Sources/Docsets/Tests/Internal/Internal/BackgroundDownloderTests.swift
@@ -42,7 +42,7 @@ final class StubDelegate: BackgroundDownloaderDelegate {
   }
 
   func downloaderGetDestinationPath(forSessionID sessionID: BoltDocsets.BackgroundDownloader.SessionTaskIdentifier) -> String? {
-    return LocalFileSystem.downloadAbsolutePath.appendingPathComponent(UUID().uuidString)
+    return LocalFileSystem.downloadsAbsolutePath.appendingPathComponent(UUID().uuidString)
   }
 
 }

--- a/BoltServices/Sources/Docsets/Tests/LibraryDocsetsManager.swift
+++ b/BoltServices/Sources/Docsets/Tests/LibraryDocsetsManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2023 Bolt Contributors
+// Copyright (C) 2024 Bolt Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,14 +28,14 @@ final class LibraryDocsetsManagerTests: XCTestCase {
 
   override func setUpWithError() throws {
     try super.setUpWithError()
-    try FileManager.default.createDirectory(atPath: LocalFileSystem.downloadAbsolutePath, withIntermediateDirectories: true)
-    try FileManager.default.copyItem(atPath: Bundle.module.path(forResource: "TestResources/Vim.tgz")!, toPath: LocalFileSystem.downloadAbsolutePath.appendingPathComponent("Vim-9.0-main.tgz"))
-    try FileManager.default.copyItem(atPath: Bundle.module.path(forResource: "TestResources/Vim.tgz.tarix")!, toPath: LocalFileSystem.downloadAbsolutePath.appendingPathComponent("Vim-9.0-main.tgz.tarix"))
+    try FileManager.default.createDirectory(atPath: LocalFileSystem.downloadsAbsolutePath, withIntermediateDirectories: true)
+    try FileManager.default.copyItem(atPath: Bundle.module.path(forResource: "TestResources/Vim.tgz")!, toPath: LocalFileSystem.downloadsAbsolutePath.appendingPathComponent("Vim-9.0-main.tgz"))
+    try FileManager.default.copyItem(atPath: Bundle.module.path(forResource: "TestResources/Vim.tgz.tarix")!, toPath: LocalFileSystem.downloadsAbsolutePath.appendingPathComponent("Vim-9.0-main.tgz.tarix"))
   }
 
   override func tearDownWithError() throws {
     try super.tearDownWithError()
-    try FileManager.default.removeItem(atPath: LocalFileSystem.downloadAbsolutePath)
+    try FileManager.default.removeItem(atPath: LocalFileSystem.downloadsAbsolutePath)
   }
 
   func testInstallDocsetWithoutTarix() async throws {

--- a/BoltServices/Sources/Types/LocalFileSystem+Extensions.swift
+++ b/BoltServices/Sources/Types/LocalFileSystem+Extensions.swift
@@ -1,0 +1,45 @@
+//
+// Copyright (C) 2024 Bolt Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import BoltUtils
+
+public extension LocalFileSystem {
+
+  private static let applicationPathPrefix = {
+    #if DEBUG
+    return "BoltDebug"
+    #else
+    return "Bolt"
+    #endif
+  }()
+
+  static let applicationDocumentsAbsolutePath: String = {
+    return LocalFileSystem.documentsAbsolutePath.appendingPathComponent(applicationPathPrefix)
+  }()
+
+  static let applicationLibraryAbsolutePath: String = {
+    return LocalFileSystem.libraryAbsolutePath.appendingPathComponent(applicationPathPrefix)
+  }()
+
+  static let applicationCachesAbsolutePath: String = {
+    return LocalFileSystem.cachesAbsolutePath.appendingPathComponent(applicationPathPrefix)
+  }()
+
+  static let applicationTempAbsolutePath: String = {
+    return LocalFileSystem.tempAbsolutePath.appendingPathComponent(applicationPathPrefix)
+  }()
+
+}

--- a/BoltUtils/Sources/LocalFileSystem.swift
+++ b/BoltUtils/Sources/LocalFileSystem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2023 Bolt Contributors
+// Copyright (C) 2024 Bolt Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public struct LocalFileSystem {
     return NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first
   }()
 
-  private static let _tmpAbsolutePath: String! = {
+  private static let _tempAbsolutePath: String! = {
     return FileManager.default.temporaryDirectory.path
   }()
 
@@ -50,8 +50,8 @@ public struct LocalFileSystem {
     return _cachesAbsolutePath!
   }()
 
-  public static let tmpAbsolutePath: String = {
-    return _tmpAbsolutePath!
+  public static let tempAbsolutePath: String = {
+    return _tempAbsolutePath!
   }()
 
 }

--- a/BoltUtils/Sources/LocalFileSystem.swift
+++ b/BoltUtils/Sources/LocalFileSystem.swift
@@ -19,7 +19,7 @@ import Foundation
 public struct LocalFileSystem {
 
   private static let _libraryAbsolutePath: String! = {
-    #if targetEnvironment(macCatalyst)
+    #if os(macOS) || targetEnvironment(macCatalyst)
     return NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first
     #else
     return NSSearchPathForDirectoriesInDomains(.libraryDirectory, .userDomainMask, true).first


### PR DESCRIPTION
Especially, extensions that returns `URL` should not contain `absolute` or `path` in their names, since `URL`s are always absolute.

Also renames `download` to `downloads` and `tmp` to `temp`.