### PR TITLE
Fix the issue that causes URLSessionDelegate to crash when running tests on Xcode 16.

### DIFF
--- a/BoltFramework/BoltPreferencesUI/CacheCleaner.swift
+++ b/BoltFramework/BoltPreferencesUI/CacheCleaner.swift
@@ -53,3 +53,13 @@ struct CacheCleaner: LoggerProvider {
   }
 
 }
+
+private extension URLSession {
+
+  func stopAllTasks() async {
+    await allTasks
+      .filter { $0.state != .completed && $0.state != .canceling }
+      .forEach { $0.cancel() }
+  }
+
+}

--- a/BoltServices/Sources/Docsets/Sources/Extensions/URLSession+Extensions.swift
+++ b/BoltServices/Sources/Docsets/Sources/Extensions/URLSession+Extensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2023 Bolt Contributors
+// Copyright (C) 2024 Bolt Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 import Foundation
 
-public extension URLSession {
+extension URLSession {
 
   func stopAllTasks() async {
     await allTasks


### PR DESCRIPTION
Weird crash in URLSession delegate queue happens when running tests on Xcode 16 on internal builds that build with xcodeproj generated with Tuist. Strangely, this does not happen with the open-source project using SPM.

[xctest-2024-09-12-070551.ips.txt](https://github.com/user-attachments/files/16988914/xctest-2024-09-12-070551.ips.txt)

Some experiments shows that it happens when `await`ing `URLSession.allTasks` from another module (BoltUtils here). I won't dive into this issue deeper, so here's the quick fix to let these tests pass.