### PR TITLE
Allow properly dismissal for LibraryDownloadsListView. (#17)

### DIFF
--- a/BoltFramework/BoltFramework/BoltAppNavigator.swift
+++ b/BoltFramework/BoltFramework/BoltAppNavigator.swift
@@ -19,10 +19,14 @@ import SwiftUI
 import BoltLibraryUI
 import BoltPreferencesUI
 
+import BoltUIFoundation
+
 struct BoltAppNavigator {
 
   static func presentLibrary() {
-    let homeViewController = UIHostingController(rootView: LibraryHomeListView())
+    let homeViewController = UIHostingController(
+      rootView: SheetContainer { LibraryHomeListView() }
+    )
     homeViewController.modalPresentationStyle = .formSheet
     if let root = UIApplication.shared.keyWindowOfActiveScene?.topViewController {
       root.present(homeViewController, animated: true)
@@ -38,7 +42,9 @@ struct BoltAppNavigator {
   }
 
   static func presentDownloads() {
-    let downloadsViewController = UIHostingController(rootView: LibraryDownloadsListView())
+    let downloadsViewController = UIHostingController(
+      rootView: SheetContainer { LibraryDownloadsListView() }
+    )
     downloadsViewController.modalPresentationStyle = .formSheet
     if let root = UIApplication.shared.keyWindowOfActiveScene?.topViewController {
       root.present(downloadsViewController, animated: true)

--- a/BoltFramework/BoltLibraryUI/Home/LibraryHomeListView.swift
+++ b/BoltFramework/BoltLibraryUI/Home/LibraryHomeListView.swift
@@ -20,21 +20,10 @@ import BoltLocalizations
 import BoltUIFoundation
 import BoltUtils
 
-private struct DismissLibraryHomeEnvironmentKey: EnvironmentKey {
-  static let defaultValue: DismissAction? = nil
-}
-
-extension EnvironmentValues {
-  var dismissLibraryHome: DismissAction? {
-    get { self[DismissLibraryHomeEnvironmentKey.self] }
-    set { self[DismissLibraryHomeEnvironmentKey.self] = newValue }
-  }
-}
-
 public struct LibraryHomeListView: View {
 
-  @Environment(\.dismiss)
-  private var dismiss: DismissAction
+  @Environment(\.dismissSheetModal)
+  private var dismissSheetModal: DismissAction?
 
   typealias Item = LibraryHomeListViewModel.Section.Item
 
@@ -73,13 +62,12 @@ public struct LibraryHomeListView: View {
       .toolbar {
         ToolbarItem(placement: .confirmationAction) {
           Button(UIKitLocalizations.done) {
-            dismiss()
+            dismissSheetModal?()
           }
         }
       }
     }
     .navigationViewStyle(.stack)
-    .environment(\.dismissLibraryHome, dismiss)
   }
 
 }

--- a/BoltFramework/BoltLibraryUI/Scenes/FeedEntry/LibraryFeedEntryView.swift
+++ b/BoltFramework/BoltLibraryUI/Scenes/FeedEntry/LibraryFeedEntryView.swift
@@ -168,8 +168,8 @@ struct LibraryFeedEntryView: View {
   @Injected(\.downloadManager)
   private var downloadManager: DownloadManager
 
-  @Environment(\.dismissLibraryHome)
-  private var dismissLibraryHome: DismissAction?
+  @Environment(\.dismissSheetModal)
+  private var dismissSheetModal: DismissAction?
 
   init(_ entry: FeedEntry) {
     self.dataSource = DataSource(entry: entry)
@@ -327,7 +327,7 @@ struct LibraryFeedEntryView: View {
     .toolbar {
       ToolbarItem(placement: .confirmationAction) {
         Button(UIKitLocalizations.done) {
-          dismissLibraryHome?()
+          dismissSheetModal?()
         }
       }
     }
@@ -360,7 +360,7 @@ struct LibraryFeedEntryView: View {
       if case .finished = completion {
         Task {
           await downloadManager.cancelDownload(forIdentifier: dataSource.entry.id)
-          dismissLibraryHome?()
+          dismissSheetModal?()
         }
       }
     })

--- a/BoltFramework/BoltLibraryUI/Scenes/FeedInfo/LibraryFeedInfoView.swift
+++ b/BoltFramework/BoltLibraryUI/Scenes/FeedInfo/LibraryFeedInfoView.swift
@@ -52,8 +52,8 @@ struct LibraryFeedInfoView: View {
 
   typealias VersionsSection = LibraryFeedInfoVersionsSection
 
-  @Environment(\.dismissLibraryHome)
-  private var dismissLibraryHome: DismissAction?
+  @Environment(\.dismissSheetModal)
+  private var dismissSheetModal: DismissAction?
 
   @Injected(\.repositoryRegistry)
   private var repositoryRegistry: RepositoryRegistry
@@ -90,7 +90,7 @@ struct LibraryFeedInfoView: View {
     .toolbar {
       ToolbarItem(placement: .confirmationAction) {
         Button(UIKitLocalizations.done) {
-          dismissLibraryHome?()
+          dismissSheetModal?()
         }
       }
     }

--- a/BoltFramework/BoltLibraryUI/Scenes/FeedList/CustomFeeds/LibraryCustomFeedListView.swift
+++ b/BoltFramework/BoltLibraryUI/Scenes/FeedList/CustomFeeds/LibraryCustomFeedListView.swift
@@ -63,8 +63,8 @@ private final class LibraryCustomFeedListViewModel: ObservableObject {
 
 struct LibraryCustomFeedListView: View {
 
-  @Environment(\.dismissLibraryHome)
-  private var dismissLibraryHome: DismissAction?
+  @Environment(\.dismissSheetModal)
+  private var dismissSheetModal: DismissAction?
 
   @ObservedObject private var model = LibraryCustomFeedListViewModel()
 
@@ -136,7 +136,7 @@ struct LibraryCustomFeedListView: View {
     .toolbar {
       ToolbarItem(placement: .confirmationAction) {
         Button(UIKitLocalizations.done) {
-          dismissLibraryHome?()
+          dismissSheetModal?()
         } // Button
       } // ToolbarItem
       ToolbarItemGroup(placement: .bottomBar) {

--- a/BoltFramework/BoltLibraryUI/Scenes/FeedList/LibraryFeedListView.swift
+++ b/BoltFramework/BoltLibraryUI/Scenes/FeedList/LibraryFeedListView.swift
@@ -55,8 +55,8 @@ class RefreshActionPerformer: ObservableObject {
 
 struct LibraryFeedListRefreshableListWrapper<Model>: View where Model: LibraryFeedListViewModel {
 
-  @Environment(\.dismissLibraryHome)
-  private var dismissLibraryHome: DismissAction?
+  @Environment(\.dismissSheetModal)
+  private var dismissSheetModal: DismissAction?
 
   @StateObject private var model = Model()
   @StateObject private var actionPerformer = RefreshActionPerformer()
@@ -79,7 +79,7 @@ struct LibraryFeedListRefreshableListWrapper<Model>: View where Model: LibraryFe
       .toolbar {
         ToolbarItem(placement: .confirmationAction) {
           Button(UIKitLocalizations.done) {
-            dismissLibraryHome?()
+            dismissSheetModal?()
           }
         }
       }

--- a/BoltFramework/BoltUIFoundation/Components/SwiftUI/SheetContainer.swift
+++ b/BoltFramework/BoltUIFoundation/Components/SwiftUI/SheetContainer.swift
@@ -1,0 +1,45 @@
+//
+// Copyright (C) 2024 Bolt Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+private struct DismissSheetModalEnvironmentKey: EnvironmentKey {
+  static let defaultValue: DismissAction? = nil
+}
+
+public extension EnvironmentValues {
+  var dismissSheetModal: DismissAction? {
+    get { self[DismissSheetModalEnvironmentKey.self] }
+    set { self[DismissSheetModalEnvironmentKey.self] = newValue }
+  }
+}
+
+public struct SheetContainer<Content: View>: View {
+
+  @Environment(\.dismiss)
+  private var dismiss: DismissAction
+
+  public init(@ViewBuilder content: @escaping () -> Content) {
+    self.content = content
+  }
+
+  private let content: () -> Content
+
+  public var body: some View {
+    content()
+      .environment(\.dismissSheetModal, dismiss)
+  }
+}


### PR DESCRIPTION
This is a temporary hack under current structure by injecting `dismissSheetModal` EnvironmentValue. Will be reimplemented when adapting iOS 16's `NavigationStack`.