### PR TITLE
Fix concurrent access to loggers.

### DIFF
--- a/BoltUtils/Sources/Logger/Loggers.swift
+++ b/BoltUtils/Sources/Logger/Loggers.swift
@@ -37,11 +37,17 @@ public extension LoggerProvider {
 
 }
 
-public actor Loggers {
+public struct Loggers {
 
-  private static var loggers: [String: Logger] = [:]
+  nonisolated(unsafe) private static var loggers: [String: Logger] = [:]
+
+  private static let loggerAccessLock = NSLock()
 
   public static func forCategory(_ category: String) -> Logger {
+    loggerAccessLock.lock()
+    defer {
+      loggerAccessLock.unlock()
+    }
     if let logger = loggers[category] {
       return logger
     }


### PR DESCRIPTION
Partially reverts 87b2d97. Actors do not isolate static properties.

```
==================
WARNING: ThreadSanitizer: Swift access race (pid=78287)
  Modifying access of Swift variable at 0x00010a633a78 by thread T9:
    #0 static BoltUtils.Loggers.forCategory(Swift.String) -> os.Logger <null> (BoltFramework:arm64+0x33bb90)
    #1 static (extension in BoltUtils):BoltUtils.LoggerProvider.logger.getter : os.Logger <null> (BoltFramework:arm64+0x33b748)
    #2 BoltSearch.DocsetIndexer.addSearchIndexToQueue(BoltSearch.DocsetSearchIndex) -> () <null> (BoltFramework:arm64+0xd576a8)
    #3 (2) suspend resume partial function for BoltSearch.SearchServiceImp.queueToCreateSearchIndex(BoltSearch.DocsetSearchIndex) async -> () <null> (BoltFramework:arm64+0xd79fc8)
    #4 swift::runJobInEstablishedExecutorContext(swift::Job*) <null> (libswift_Concurrency.dylib:arm64e+0x61278)

  Previous read of size 8 at 0x00010a633a78 by thread T19:
    #0 static BoltUtils.Loggers.forCategory(Swift.String) -> os.Logger <null> (BoltFramework:arm64+0x33b990)
    #1 static (extension in BoltUtils):BoltUtils.LoggerProvider.logger.getter : os.Logger <null> (BoltFramework:arm64+0x33b748)
    #2 closure #1 (GRDB.Database.TraceEvent) -> () in closure #1 (GRDB.Database) -> () in BoltDatabase.LibraryDatabase.() -> BoltDatabase.LibraryDatabase(in _747104774C34D0007C6CF1D582E748C4).init() -> BoltDatabase.LibraryDatabase <null> (BoltFramework:arm64+0xabee68)
    #3 partial apply forwarder for closure #1 (GRDB.Database.TraceEvent) -> () in closure #1 (GRDB.Database) -> () in BoltDatabase.LibraryDatabase.() -> BoltDatabase.LibraryDatabase(in _747104774C34D0007C6CF1D582E748C4).init() -> BoltDatabase.LibraryDatabase <null> (BoltFramework:arm64+0xac7478)
    #4 GRDB.Database.(trace_v2 in _5B3880C46E61F0AD1FB0C2165AC1D6E8)(Swift.Int32, Swift.Optional<Swift.UnsafeMutableRawPointer>, Swift.Optional<Swift.UnsafeMutableRawPointer>, @convention(c) (Swift.Optional<Swift.OpaquePointer>) -> Swift.Optional<Swift.UnsafeMutablePointer<Swift.Int8>>) -> () <null> (BoltFramework:arm64+0x5dbaa4)
    #5 closure #1 (Swift.UInt32, Swift.Optional<Swift.UnsafeMutableRawPointer>, Swift.Optional<Swift.UnsafeMutableRawPointer>, Swift.Optional<Swift.UnsafeMutableRawPointer>) -> Swift.Int32 in GRDB.Database.trace(options: GRDB.Database.TracingOptions, _: Swift.Optional<(GRDB.Database.TraceEvent) -> ()>) -> () <null> (BoltFramework:arm64+0x5db638)
    #6 @objc closure #1 (Swift.UInt32, Swift.Optional<Swift.UnsafeMutableRawPointer>, Swift.Optional<Swift.UnsafeMutableRawPointer>, Swift.Optional<Swift.UnsafeMutableRawPointer>) -> Swift.Int32 in GRDB.Database.trace(options: GRDB.Database.TracingOptions, _: Swift.Optional<(GRDB.Database.TraceEvent) -> ()>) -> () <null> (BoltFramework:arm64+0x5dbd98)
    #7 sqlite3VdbeExec <null> (libsqlite3.dylib:arm64e+0x388ec)
    #8 GRDB.Statement.execute(arguments: Swift.Optional<GRDB.StatementArguments>) throws -> () <null> (BoltFramework:arm64+0x6c0f34)
    #9 GRDB.Database.execute(literal: GRDB.SQL) throws -> () <null> (BoltFramework:arm64+0x5c6dac)
    #10 GRDB.Database.execute(sql: Swift.String, arguments: GRDB.StatementArguments) throws -> () <null> (BoltFramework:arm64+0x5c6b84)
    #11 GRDB.Database.commit() throws -> () <null> (BoltFramework:arm64+0x5ded94)
    #12 $defer #1 () -> () in closure #1 (GRDB.Database) -> () in closure #1 (Swift.Result<(element: GRDB.SerializedDatabase, release: (GRDB.PoolCompletion) -> ()), Swift.Error>) -> () in GRDB.DatabasePool.asyncRead((Swift.Result<GRDB.Database, Swift.Error>) -> ()) -> () <null> (BoltFramework:arm64+0x615ffc)
    #13 closure #1 (GRDB.Database) -> () in closure #1 (Swift.Result<(element: GRDB.SerializedDatabase, release: (GRDB.PoolCompletion) -> ()), Swift.Error>) -> () in GRDB.DatabasePool.asyncRead((Swift.Result<GRDB.Database, Swift.Error>) -> ()) -> () <null> (BoltFramework:arm64+0x615e74)
    #14 partial apply forwarder for closure #1 (GRDB.Database) -> () in closure #1 (Swift.Result<(element: GRDB.SerializedDatabase, release: (GRDB.PoolCompletion) -> ()), Swift.Error>) -> () in GRDB.DatabasePool.asyncRead((Swift.Result<GRDB.Database, Swift.Error>) -> ()) -> () <null> (BoltFramework:arm64+0x61f84c)
    #15 closure #1 @Sendable () -> () in GRDB.SerializedDatabase.async((GRDB.Database) -> ()) -> () <null> (BoltFramework:arm64+0x6b8a48)
    #16 partial apply forwarder for closure #1 @Sendable () -> () in GRDB.SerializedDatabase.async((GRDB.Database) -> ()) -> () <null> (BoltFramework:arm64+0x6b8b70)
    #17 reabstraction thunk helper from @escaping @callee_guaranteed @Sendable () -> () to @escaping @callee_unowned @convention(block) @Sendable () -> () <null> (BoltFramework:arm64+0x6b8d88)
    #18 __tsan::invoke_and_release_block(void*) <null> (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x800d4)
    #19 _dispatch_client_callout <null> (libdispatch.dylib:arm64e+0x6820)

  Location is global 'static BoltUtils.Loggers.(loggers in _0C869029B7920FF0C4478B586A956687) : Swift.Dictionary<Swift.String, os.Logger>' at 0x00010a633a78 (BoltFramework+0x153fa78)

  Thread T9 (tid=659816, running) is a GCD worker thread

  Thread T19 (tid=659909, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: Swift access race (/Users/ethanwong/Library/Developer/Xcode/DerivedData/Bolt-gcnofavunqvbqgfdfjrcmkhzmfxj/Build/Products/Debug-maccatalyst/Bolt.app/Contents/Frameworks/BoltFramework.framework/Versions/A/BoltFramework:arm64+0x33bb90) in static BoltUtils.Loggers.forCategory(Swift.String) -> os.Logger+0x3d4
==================
```