### PR TITLE
Fix the flakiness of FeedsServiceTests by removing the async dispatch.

### DIFF
--- a/BoltServices/Sources/Repository/Tests/FeedsServiceTests.swift
+++ b/BoltServices/Sources/Repository/Tests/FeedsServiceTests.swift
@@ -44,29 +44,26 @@ final class FeedsServiceTests: NetworkingStubbedTestCase {
       .sink { _ in }
       .cancel()
 
-    // wait some time to start, since we don't want the initial value sent from database observation
-    DispatchQueue.main.asyncAfter(deadline: .now().advanced(by: .milliseconds(500))) { [feedsService] in
-      let expectedResult: [[String]] = [[], [testFeed.id], []]
+    let expectedResult: [[String]] = [[], [], [testFeed.id], []]
 
-      var results = [[String]]()
+    var results = [[String]]()
 
-      feedsService.customFeedsObservable()
-        .prefix(expectedResult.count)
-        .eraseToAnyPublisher()
-        .sink(receiveCompletion: { _ in
-          XCTAssertEqual(results, expectedResult)
-          expectation.fulfill()
-        }, receiveValue: { val in
-          results.append(val.map { $0.id })
-        })
-        .store(in: &cancellableBag)
+    feedsService.customFeedsObservable()
+      .prefix(expectedResult.count)
+      .eraseToAnyPublisher()
+      .sink(receiveCompletion: { _ in
+        XCTAssertEqual(results, expectedResult)
+        expectation.fulfill()
+      }, receiveValue: { val in
+        results.append(val.map { $0.id })
+      })
+      .store(in: &cancellableBag)
 
-      do {
-        try feedsService.insertCustomFeed(testFeed)
-        try feedsService.deleteCustomFeeds(testFeed)
-      } catch {
-        XCTFail("error thrown: \(error)")
-      }
+    do {
+      try feedsService.insertCustomFeed(testFeed)
+      try feedsService.deleteCustomFeeds(testFeed)
+    } catch {
+      XCTFail("error thrown: \(error)")
     }
 
     wait(for: [expectation], timeout: 5)


### PR DESCRIPTION
The `DispatchQueue.main.asyncAfter` was introduced as a workaround for https://github.com/groue/GRDB.swift/issues/937, since `ValueObservation` has different behavior for delivering initial value on different platforms (Mac Catalyst, iOS). It could be safely remove now to avoid flakiness.