### PR TITLE
Preprocess paths from the search index by removing <dash_entry_*> tags.

### DIFF
--- a/BoltFramework/BoltLookupUI/Scenes/Content/Lists/LookupListViewController.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/Content/Lists/LookupListViewController.swift
@@ -226,7 +226,7 @@ private final class StubbedLookupListViewModel: LookupListViewModel {
         entryItems: .success(
           [LookupListStubbedEntryItem](
             repeating: LookupListStubbedEntryItem(
-              entry: Entry(typeName: "Class", name: "MyClass", path: "")
+              entry: Entry(typeName: "Class", name: "MyClass", rawPath: "")
             ),
             count: 10
           )

--- a/BoltServices/Sources/Search/Sources/DocsetSearcher.swift
+++ b/BoltServices/Sources/Search/Sources/DocsetSearcher.swift
@@ -90,7 +90,7 @@ struct DocsetSearcher {
     let results = try request.fetchAll(db)
     return results.compactMap { result -> Entry? in
       let included = shouldInclude?(result) ?? true
-      return included ? Entry(typeName: result.type, name: result.name, path: result.path) : nil
+      return included ? Entry(typeName: result.type, name: result.name, rawPath: result.path) : nil
     }
   }
 

--- a/BoltServices/Sources/Search/Sources/Types/Entry.swift
+++ b/BoltServices/Sources/Search/Sources/Types/Entry.swift
@@ -24,17 +24,23 @@ public struct Entry {
 
   public let typeName: String
   public let name: String
-  public let path: String
+  public let rawPath: String
 
+  public private(set) var path = ""
 
   public var type: EntryType? {
     return EntryType.type(forNameOrAlias: typeName)
   }
 
-  public init(typeName: String, name: String, path: String) {
+  public init(typeName: String, name: String, rawPath: String) {
     self.typeName = typeName
     self.name = name
-    self.path = path
+    self.rawPath = rawPath
+    parseRawPath()
+  }
+
+  private mutating func parseRawPath() {
+    path = rawPath.replacing(#/<dash_entry_.*?>/#) { _ in "" }
   }
 
 }


### PR DESCRIPTION
Some docsets like C++ may have paths with `<dash_entry_*>` in search indices:

```
<dash_entry_name=Hash%20%28since%20C%2B%2B11%29><dash_entry_originalName=Hash%20><dash_entry_menuDescription=Hash%20>en.cppreference.com/w/cpp/named_req/Hash.html
```

Theses tags provides information to support nested search results and should be removed before being loaded as the actual page path.

See also at: https://github.com/BoltDocs/Dash-iOS/blob/758c24e/Dash/DHDBResult.m#L444.
