### PR TITLE
Liquid Glass: tweak the home view navbar buttons layout. (#41)

### DIFF
--- a/BoltFramework/BoltHomeUI/ToolbarDownloadsItemView.swift
+++ b/BoltFramework/BoltHomeUI/ToolbarDownloadsItemView.swift
@@ -57,6 +57,9 @@ final class ToolbarDownloadsItemView: UIView {
     update(ItemButton(type: .system)) {
       $0.setTitle("Home-Toolbar-DownloadsButtonTitle".boltLocalized, for: .normal)
       $0.titleLabel?.font = UIFont.systemFont(ofSize: 17)
+      if #available(iOS 26.0, *) {
+        $0.tintColor = .label
+      }
     }
   }()
 
@@ -64,6 +67,9 @@ final class ToolbarDownloadsItemView: UIView {
     update(ItemButton(type: .system)) {
       $0.setTitle("Home-Toolbar-UpdatesButtonTitle".boltLocalized, for: .normal)
       $0.titleLabel?.font = UIFont.systemFont(ofSize: 11)
+      if #available(iOS 26.0, *) {
+        $0.tintColor = .label
+      }
     }
   }()
 


### PR DESCRIPTION
Take the Files app as an example, here are the notable changes we have to adapt:

1. All buttons are no longer tinted.

2. The More button has its icon updated with ellipses without the circle.

3. The sidebar toggle got moved to the right side, so the Done button has to be moved to the left side.

* Sidebar:

<img width="640" alt="Sidebar" src="https://github.com/user-attachments/assets/a88f96bd-5700-43f5-809e-6d618b14993f" />

* Sidebar Editing:

<img width="640" alt="Sidebar Editing" src="https://github.com/user-attachments/assets/899625e5-f583-459e-9aa4-b54370c1bf72" />

