### PR TITLE
Refine the lookup list navigation bar appearance for pre-OS 26 UI.

### DIFF
--- a/BoltFramework/BoltLookupUI/Scenes/Content/LookupContentViewController.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/Content/LookupContentViewController.swift
@@ -55,10 +55,6 @@ public final class LookupContentViewController: UIViewController, HasDisposeBag 
 
     with(navigationItem) {
       $0.largeTitleDisplayMode = .never
-      $0.scrollEdgeAppearance = update(UINavigationBarAppearance()) {
-        $0.configureWithDefaultBackground()
-        $0.shadowColor = .clear
-      }
     }
 
     addChild(browserViewController) {
@@ -125,11 +121,20 @@ public final class LookupContentViewController: UIViewController, HasDisposeBag 
     forLookupListVisible lookupVisible: Bool,
     showsDocPage: Bool
   ) {
-    let navigationBar = navigationController?.navigationBar
+    if navigationItem.standardAppearance == nil {
+      navigationItem.standardAppearance = UINavigationBarAppearance()
+    }
+    if navigationItem.scrollEdgeAppearance == nil {
+      navigationItem.scrollEdgeAppearance = UINavigationBarAppearance()
+    }
+
     if lookupVisible, !showsDocPage {
-      navigationBar?.standardAppearance.configureWithOpaqueBackground()
+      navigationItem.standardAppearance?.configureWithOpaqueBackground()
+      navigationItem.scrollEdgeAppearance?.configureWithOpaqueBackground()
     } else {
-      navigationBar?.standardAppearance.configureWithDefaultBackground()
+      navigationItem.standardAppearance?.configureWithDefaultBackground()
+      navigationItem.scrollEdgeAppearance?.configureWithDefaultBackground()
+      navigationItem.scrollEdgeAppearance?.shadowColor = .clear
     }
   }
 


### PR DESCRIPTION
On pre-OS 26 UI, when presenting the lookup list, the navigation bar keeps the appearance it had before the presentation. So we have to modify the `scrollEdgeAppearance` accordingly along with `standardAppearance`.

Also adopt `navigationItem` instead of directly modifying the navigation bar appearance.

https://github.com/user-attachments/assets/6da36402-2c93-4f29-b0ff-f87b4124a074

When the lookup list is presented, the navigation bar should be opaque with a shadow, regardless of the scroll position.

<img width="1200" src="https://github.com/user-attachments/assets/ca6c8dd5-294d-4e74-bce2-a994c53e6dd6" />
