### PR TITLE
Liquid Glass: optimizing the lookup view navigation bar background.

### DIFF
--- a/BoltFramework/BoltLookupUI/Scenes/Content/LookupContentViewController.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/Content/LookupContentViewController.swift
@@ -20,11 +20,18 @@ import BoltBrowserUI
 import BoltModuleExports
 import BoltRxSwift
 import BoltUIFoundation
+import BoltUtils
 
 import Overture
 import SnapKit
 
 public final class LookupContentViewController: UIViewController, HasDisposeBag {
+
+  private let systemNavigationBarShadowColor: UIColor? = {
+    let appearance = UINavigationBarAppearance()
+    appearance.configureWithOpaqueBackground()
+    return appearance.shadowColor
+  }()
 
   private let sceneState: SceneState
 
@@ -59,8 +66,15 @@ public final class LookupContentViewController: UIViewController, HasDisposeBag 
 
     addChild(browserViewController) {
       view.addSubview($0)
-      $0.snp.makeConstraints {
-        $0.edges.equalToSuperview()
+      if RuntimeEnvironment.isOS26UIEnabled {
+        $0.snp.makeConstraints {
+          $0.top.equalTo(view.safeAreaLayoutGuide)
+          $0.leading.trailing.bottom.equalToSuperview()
+        }
+      } else {
+        $0.snp.makeConstraints {
+          $0.edges.equalToSuperview()
+        }
       }
     }
 
@@ -128,13 +142,24 @@ public final class LookupContentViewController: UIViewController, HasDisposeBag 
       navigationItem.scrollEdgeAppearance = UINavigationBarAppearance()
     }
 
-    if lookupVisible, !showsDocPage {
-      navigationItem.standardAppearance?.configureWithOpaqueBackground()
-      navigationItem.scrollEdgeAppearance?.configureWithOpaqueBackground()
+    if RuntimeEnvironment.isOS26UIEnabled {
+      if lookupVisible, !showsDocPage {
+        navigationItem.standardAppearance?.configureWithDefaultBackground()
+        navigationItem.scrollEdgeAppearance?.configureWithDefaultBackground()
+      } else {
+        navigationItem.standardAppearance?.configureWithDefaultBackground()
+        navigationItem.standardAppearance?.shadowColor = systemNavigationBarShadowColor
+        navigationItem.scrollEdgeAppearance?.configureWithDefaultBackground()
+      }
     } else {
-      navigationItem.standardAppearance?.configureWithDefaultBackground()
-      navigationItem.scrollEdgeAppearance?.configureWithDefaultBackground()
-      navigationItem.scrollEdgeAppearance?.shadowColor = .clear
+      if lookupVisible, !showsDocPage {
+        navigationItem.standardAppearance?.configureWithOpaqueBackground()
+        navigationItem.scrollEdgeAppearance?.configureWithOpaqueBackground()
+      } else {
+        navigationItem.standardAppearance?.configureWithDefaultBackground()
+        navigationItem.scrollEdgeAppearance?.configureWithDefaultBackground()
+        navigationItem.scrollEdgeAppearance?.shadowColor = .clear
+      }
     }
   }
 


### PR DESCRIPTION
It's way too tricky to get the scroll-edge appearance done right on OS 26 without visual glitches, so for now we have to pin the top of the browser view to the safe area to avoid such effects.

The shadow color for `UINavigationBarAppearance.configureWithDefaultBackground()` appears to have changed on OS 26:

```swift
let appearance = UINavigationBarAppearance() 
appearance.configureWithDefaultBackground()
print("backgroundColor: \(appearance.backgroundColor)")
print("shadowColor: \(appearance.shadowColor)")
```

pre-OS 26:
```swift
backgroundColor: nil
shadowColor: Optional(<UIDynamicSystemColor: 0x1282ef240; name = _systemChromeShadowColor>)
```

OS 26:
```swift
backgroundColor: nil
shadowColor: nil
```

Opaque background appearance is unusable on OS 26 due to the animation hitch when navigating back.

However, we can still obtain the private background and shadow colors from `UINavigationBarAppearance.configureWithOpaqueBackground()`:

```swift
backgroundColor: Optional(<UIDynamicSystemColor: 0x101b25540; name = systemBackgroundColor>)
shadowColor: Optional(<UIDynamicSystemColor: 0x101b26600; name = _systemChromeShadowColor>)
```