### PR TITLE
Optimize the keyboard dismiss behavior for the lookup scene.

### DIFF
--- a/BoltFramework/BoltBrowserUI/Scenes/Browser/BrowserView.swift
+++ b/BoltFramework/BoltBrowserUI/Scenes/Browser/BrowserView.swift
@@ -106,6 +106,9 @@ final class BrowserView: UIView, LoggerProvider, HasDisposeBag {
 
     webView = WKWebView(frame: .zero, configuration: configuration)
 
+    let scrollView = webView.scrollView
+    scrollView.keyboardDismissMode = .interactiveWithAccessory
+
     if UserDefaults.standard.webViewInspectable {
       webView.isInspectable = true
     }

--- a/BoltFramework/BoltLookupUI/Scenes/LookupList/LookupListViewController.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/LookupList/LookupListViewController.swift
@@ -146,7 +146,7 @@ final class LookupListViewController<ListViewModel: LookupListViewModel>: BaseVi
     // Used to remove separators on empty cells
     tableView.tableFooterView = UIView()
 
-    tableView.keyboardDismissMode = .onDrag
+    tableView.keyboardDismissMode = .interactiveWithAccessory
 
     tableView.rowHeight = 44
     tableView.sectionHeaderHeight = 44

--- a/BoltFramework/BoltLookupUI/Scenes/LookupSearchViewController.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/LookupSearchViewController.swift
@@ -211,9 +211,6 @@ extension LookupSearchController: UISearchBarDelegate {
   }
 
   public func textFieldDidEndEditing(_ textField: UITextField) {
-    if !state.presentsLookupList {
-      dismiss(animated: true)
-    }
     restoreSearchFieldText()
   }
 


### PR DESCRIPTION
In all cases, whether the lookup list is visible or not, we should adopt the `interactiveWithAccessory` keyboard dismiss mode, and avoid dismissing the search controller when the search field ends editing. Follow-up to f89106f.