### PR TITLE
Update the lookup list back to dismiss the keyboard on drag since it's more intuitive.

### DIFF
--- a/BoltFramework/BoltLookupUI/Scenes/LookupList/LookupListViewController.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/LookupList/LookupListViewController.swift
@@ -146,7 +146,7 @@ final class LookupListViewController<ListViewModel: LookupListViewModel>: BaseVi
     // Used to remove separators on empty cells
     tableView.tableFooterView = UIView()
 
-    tableView.keyboardDismissMode = .interactiveWithAccessory
+    tableView.keyboardDismissMode = .onDragWithAccessory
 
     tableView.rowHeight = 44
     tableView.sectionHeaderHeight = 44


### PR DESCRIPTION
Partially reverts f5ac9f5.

The availability of `.onDrag` is iOS 7.0+ & tvOS 9.0+, while for `.onDragWithAccessory` it's iOS 7.0+ & tvOS 16.0+.

Testing on both iOS 18 & 26 shows no difference between these two modes, so it reasonable to assume that they only differs on tvOS. Still, we use `.onDragWithAccessory` here as it is more self-explanatory.