### PR TITLE
Liquid Glass: work around for the search cancellation issue on iPad. (#56)

### DIFF
--- a/BoltFramework/BoltLookupUI/Scenes/LookupList/LookupListViewModel.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/LookupList/LookupListViewModel.swift
@@ -22,10 +22,14 @@ protocol LookupListViewModel {
 
   var title: Driver<String> { get }
 
+  var hasSearchConstraints: Driver<Bool> { get }
+
   var showsLoadingIndicator: Driver<Bool> { get }
 
   var results: Driver<Result<[LookupListCellItem], Error>> { get }
 
   var itemSelected: PublishRelay<LookupListCellItem> { get }
+
+  func onClickCancel()
 
 }

--- a/BoltFramework/BoltLookupUI/Scenes/LookupList/ViewModels/LookupAllEntriesViewModel.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/LookupList/ViewModels/LookupAllEntriesViewModel.swift
@@ -39,6 +39,11 @@ final class LookupAllEntriesViewModel: LookupListViewModel {
     return _title.asDriver()
   }
 
+  private let _hasSearchConstraints = BehaviorRelay<Bool>(value: false)
+  var hasSearchConstraints: Driver<Bool> {
+    return _hasSearchConstraints.asDriver()
+  }
+
   private let _showsLoadingIndicator = BehaviorRelay<Bool>(value: false)
   var showsLoadingIndicator: Driver<Bool> {
     return _showsLoadingIndicator.asDriver()
@@ -76,6 +81,16 @@ final class LookupAllEntriesViewModel: LookupListViewModel {
     Observable.just(docset.displayName)
       .bind(to: _title)
       .disposed(by: disposeBag)
+
+    Driver.combineLatest(
+      routingState.searchQuery,
+      routingState.searchTokens
+    )
+    .map { query, tokens in
+      return !query.isEmpty || !tokens.isEmpty
+    }
+    .drive(_hasSearchConstraints)
+    .disposed(by: disposeBag)
 
     activityIndicator
       .asObservable()
@@ -121,6 +136,10 @@ final class LookupAllEntriesViewModel: LookupListViewModel {
     .startWith(.success([]))
     .bind(to: _results)
     .disposed(by: disposeBag)
+  }
+
+  func onClickCancel() {
+    routingState.dismissSearch()
   }
 
 }

--- a/BoltFramework/BoltLookupUI/Scenes/LookupList/ViewModels/LookupTypeFilteringViewModel.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/LookupList/ViewModels/LookupTypeFilteringViewModel.swift
@@ -40,6 +40,11 @@ final class LookupTypeFilteringViewModel: LookupListViewModel {
     return _title.asDriver()
   }
 
+  private let _hasSearchConstraints = BehaviorRelay<Bool>(value: false)
+  var hasSearchConstraints: Driver<Bool> {
+    return _hasSearchConstraints.asDriver()
+  }
+
   private let _showsLoadingIndicator = BehaviorRelay<Bool>(value: false)
   var showsLoadingIndicator: Driver<Bool> {
     return _showsLoadingIndicator
@@ -73,6 +78,16 @@ final class LookupTypeFilteringViewModel: LookupListViewModel {
     Observable.just(type.plural)
       .bind(to: _title)
       .disposed(by: disposeBag)
+
+    Driver.combineLatest(
+      routingState.searchQuery,
+      routingState.searchTokens
+    )
+    .map { query, tokens in
+      return !query.isEmpty || !tokens.isEmpty
+    }
+    .drive(_hasSearchConstraints)
+    .disposed(by: disposeBag)
 
     activityIndicator
       .asObservable()
@@ -118,6 +133,10 @@ final class LookupTypeFilteringViewModel: LookupListViewModel {
     .startWith(.success([]))
     .bind(to: _results)
     .disposed(by: disposeBag)
+  }
+
+  func onClickCancel() {
+    routingState.dismissSearch()
   }
 
 }

--- a/BoltFramework/BoltLookupUI/Scenes/LookupSearchViewController.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/LookupSearchViewController.swift
@@ -139,6 +139,12 @@ public final class LookupSearchController: UISearchController, HasDisposeBag {
       }
       .disposed(by: disposeBag)
 
+    state.dismissSearchDriver
+      .emit(with: self) { owner, _ in
+        owner.dismiss(animated: true)
+      }
+      .disposed(by: disposeBag)
+
     searchBar.rx.value
       .map { return $0 ?? "" }
       .subscribe(with: self) { owner, searchQuery in

--- a/BoltFramework/BoltLookupUI/States/LookupRoutingState.swift
+++ b/BoltFramework/BoltLookupUI/States/LookupRoutingState.swift
@@ -95,6 +95,9 @@ final class LookupRoutingState: HasDisposeBag {
   private let clearSearchTextSubject = PublishSubject<Void>()
   lazy var clearSearchText: Signal<Void> = { clearSearchTextSubject.asSignalOnErrorJustIgnore() }()
 
+  private let dismissSearchSubject = PublishSubject<Void>()
+  lazy var dismissSearchDriver: Signal<Void> = { dismissSearchSubject.asSignalOnErrorJustIgnore() }()
+
   lazy var tokenColor: Driver<BoltColorResource?> = {
     return routingCoordinator.currentRoute
       .map { route -> BoltColorResource? in
@@ -158,6 +161,10 @@ final class LookupRoutingState: HasDisposeBag {
 
   func updateSearchQuery(_ query: String) {
     searchQueryRelay.accept(query)
+  }
+
+  func dismissSearch() {
+    dismissSearchSubject.onNext(())
   }
 
   func selectEntry(docset: Docset, entry: Entry) {

--- a/BoltRxSwift/Sources/UITraitChangeObservable+Rx.swift
+++ b/BoltRxSwift/Sources/UITraitChangeObservable+Rx.swift
@@ -1,0 +1,47 @@
+//
+// Copyright (C) 2025 Bolt Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+public extension Reactive where Base: UITraitChangeObservable & UITraitEnvironment {
+
+  @MainActor
+  func traitChanges(traits: [UITrait]) -> ControlEvent<UITraitCollection> {
+    let source: Observable<UITraitCollection> = Observable.create { [weak target = base] observer in
+      MainScheduler.ensureRunningOnMainThread()
+
+      guard let target = target else {
+        observer.on(.completed)
+        return Disposables.create()
+      }
+
+      let registration = target.registerForTraitChanges(traits) { (traitEnvironment: Base, _) in
+        observer.on(.next(traitEnvironment.traitCollection))
+      }
+
+      return Disposables.create { [weak target] in
+        target?.unregisterForTraitChanges(registration)
+      }
+    }
+    .take(until: deallocated)
+
+    return ControlEvent(events: source)
+  }
+
+}


### PR DESCRIPTION
Fixes #56.

To allow iPad users to be able to dismiss search when the search field is empty, we add a cancel button to the lookup list navigation bar when certain conditions are met.