### PR TITLE
Prefer using toolbarItems instead of the custom UIToolbar whenever possible.

### DIFF
--- a/BoltFramework/BoltLookupUI/Scenes/Content/LookupContentViewController.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/Content/LookupContentViewController.swift
@@ -41,6 +41,12 @@ public final class LookupContentViewController: UIViewController, HasDisposeBag 
 
   private lazy var toolbar = UIToolbar()
 
+  private var toolbarMode: ToolbarMode = .normal {
+    didSet {
+      toolbarManager.mode = toolbarMode
+    }
+  }
+
   public init(sceneState: SceneState) {
     self.sceneState = sceneState
     browserViewController = BrowserViewController(sceneState: sceneState)
@@ -119,7 +125,7 @@ public final class LookupContentViewController: UIViewController, HasDisposeBag 
           return .normal
         }
       }()
-      owner.toolbarManager.mode = mode
+      owner.toolbarMode = mode
     }
     .disposed(by: disposeBag)
 
@@ -204,10 +210,16 @@ extension LookupContentViewController: ToolbarManagerDelegate {
   }
 
   func toolbarManager(_ toolbarManager: ToolbarManager, updateToolbarItems items: [UIBarButtonItem]) {
-    if RuntimeEnvironment.isOS26UIEnabled {
-      toolbar.items = items
-    } else {
+    guard RuntimeEnvironment.isOS26UIEnabled else {
       toolbarItems = items
+      return
+    }
+    if case .normal = toolbarMode {
+      toolbarItems = items
+      toolbar.items = []
+    } else {
+      toolbar.items = items
+      toolbarItems = []
     }
   }
 


### PR DESCRIPTION
Prefer using toolbarItems instead of the custom UIToolbar whenever possible.

Partially reverts f5f29bb.

Previously we introduced the custom UIToolbar to resolve #54. However the custom toolbar has janky animations when dismissing a menu.

Therefore, we should stick to toolbarItems for a navigationController managed toolbar when the search is not active.


https://github.com/user-attachments/assets/72459d11-0f33-441b-82bc-da39ed7e5a4f

