### PR TITLE
Refine table of contents implementation. (#66)

### DIFF
--- a/BoltFramework/BoltFramework/SceneManager.swift
+++ b/BoltFramework/BoltFramework/SceneManager.swift
@@ -67,8 +67,6 @@ public final class SceneManager {
   private lazy var homeViewControllerCompact = HomeViewController(sceneState: state, isForCollapsedSidebar: true)
   private lazy var homeViewControllerRegular = HomeViewController(sceneState: state, isForCollapsedSidebar: false)
 
-  private lazy var lookupSearchController = LookupSearchController(sceneState: state)
-
   private lazy var secondaryNavigationController = SecondaryNavigationController()
 
   private lazy var welcomeViewController = WelcomeViewController()
@@ -112,12 +110,6 @@ public final class SceneManager {
         )
       })
       .disposed(by: disposeBag)
-
-    with(lookupContentViewController) {
-      $0.navigationItem.searchController = lookupSearchController
-      $0.navigationItem.hidesSearchBarWhenScrolling = false
-      $0.navigationItem.preferredSearchBarPlacement = .stacked
-    }
 
     with(doubleColumnSplitViewController) {
       $0.setViewController(homePrimaryNavigationController, for: .primary)

--- a/BoltFramework/BoltLookupUI/Scenes/Content/LookupContentViewController.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/Content/LookupContentViewController.swift
@@ -36,6 +36,7 @@ public final class LookupContentViewController: UIViewController, HasDisposeBag 
   private let sceneState: SceneState
 
   private let browserViewController: BrowserViewController
+  private let lookupSearchController: LookupSearchController
 
   private var toolbarManager: ToolbarManager!
 
@@ -50,13 +51,15 @@ public final class LookupContentViewController: UIViewController, HasDisposeBag 
   public init(sceneState: SceneState) {
     self.sceneState = sceneState
     browserViewController = BrowserViewController(sceneState: sceneState)
+    lookupSearchController = LookupSearchController(sceneState: sceneState)
 
     super.init(nibName: nil, bundle: nil)
 
     let findInPageViewModel = FindInPageToolbarViewModel(sceneState: sceneState)
     toolbarManager = ToolbarManager(
-      delegate: self,
-      findInPageToolbarViewModel: findInPageViewModel
+      sceneState: sceneState,
+      findInPageToolbarViewModel: findInPageViewModel,
+      delegate: self
     )
   }
 
@@ -72,6 +75,9 @@ public final class LookupContentViewController: UIViewController, HasDisposeBag 
 
     with(navigationItem) {
       $0.largeTitleDisplayMode = .never
+      $0.searchController = lookupSearchController
+      $0.hidesSearchBarWhenScrolling = false
+      $0.preferredSearchBarPlacement = .stacked
     }
 
     addChild(browserViewController) {
@@ -204,6 +210,10 @@ extension LookupContentViewController: ToolbarManagerDelegate {
 
   func toolbarManagerDidTapGoForward(_ toolbarManager: ToolbarManager) {
     browserViewController.goForward()
+  }
+
+  func toolbarManagerDidTapTableOfContents(_ toolbarManager: ToolbarManager) {
+    lookupSearchController.presentTableOfContents()
   }
 
   func toolbarManagerDidTapZoomIn(_ toolbarManager: ToolbarManager) {

--- a/BoltFramework/BoltLookupUI/Scenes/LookupList/LookupTableOfContentsViewController.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/LookupList/LookupTableOfContentsViewController.swift
@@ -29,7 +29,7 @@ final class LookupTableOfContentsViewController: UINavigationController, HasDisp
   init(sceneState: SceneState, routingState: LookupRoutingState) {
     self.sceneState = sceneState
     self.routingState = routingState
-    super.init(rootViewController: LookupInitialViewController())
+    super.init(nibName: nil, bundle: nil)
   }
 
   @available(*, unavailable)

--- a/BoltFramework/BoltLookupUI/Scenes/LookupSearchViewController.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/LookupSearchViewController.swift
@@ -123,6 +123,20 @@ public final class LookupSearchController: UISearchController, HasDisposeBag {
       .drive(searchBar.rx.selectedScopeButtonIndex)
       .disposed(by: disposeBag)
 
+    state.hasTableOfContents
+      .drive(with: self) { owner, hasTableOfContents in
+        owner.searchBar.scopeButtonTitles = hasTableOfContents ? [
+          LookupSearchScope.types.displayTitle,
+          LookupSearchScope.docPage.displayTitle,
+          LookupSearchScope.tableOfContents.displayTitle,
+        ] : [
+          LookupSearchScope.types.displayTitle,
+          LookupSearchScope.docPage.displayTitle,
+        ]
+        owner.scopeBarSetNeedsLayout()
+      }
+      .disposed(by: disposeBag)
+
     state.searchTokens
       .drive(with: self) { owner, tokens in
         let searchTextField = owner.searchBar.searchTextField
@@ -153,6 +167,24 @@ public final class LookupSearchController: UISearchController, HasDisposeBag {
         owner.state.updateSearchQuery(searchQuery)
       }
       .disposed(by: disposeBag)
+  }
+
+  // MARK: Interfaces
+
+  func presentTableOfContents() {
+    isActive = true
+    state.selectSearchScope(.tableOfContents)
+  }
+
+  // MARK: Private
+
+  private func scopeBarSetNeedsLayout() {
+    if let containerView = searchBar.scopeBar?.superview {
+      #if DEBUG
+      assert(String(describing: type(of: containerView)) == "_UISearchBarScopeContainerView")
+      #endif
+      containerView.setNeedsLayout()
+    }
   }
 
 }

--- a/BoltFramework/BoltLookupUI/States/LookupRoutingState.swift
+++ b/BoltFramework/BoltLookupUI/States/LookupRoutingState.swift
@@ -91,6 +91,8 @@ final class LookupRoutingState: HasDisposeBag {
 
   var sceneTitle: Driver<String> { sceneState.lookupSceneTitle }
 
+  var hasTableOfContents: Driver<Bool> { sceneState.lookupHasTableOfContents }
+
   private let searchQueryRelay = BehaviorRelay<String>(value: "")
   lazy var searchQuery: Driver<String> = { searchQueryRelay.asDriver() }()
 
@@ -173,6 +175,10 @@ final class LookupRoutingState: HasDisposeBag {
   }()
 
   // MARK: - Interfaces
+
+  func updateHasTableOfContents(_ value: Bool) {
+    sceneState.dispatch(action: .updateLookupHasTableOfContents(value))
+  }
 
   func updateSearchQuery(_ query: String) {
     searchQueryRelay.accept(query)

--- a/BoltFramework/BoltModuleExports/SceneState.swift
+++ b/BoltFramework/BoltModuleExports/SceneState.swift
@@ -57,6 +57,7 @@ public enum SceneAction {
   case updateCurrentScope(_: LookupScope)
   case updateDocPageCurrentURL(_: URL?)
   case updateLookupSceneTitle(_: String)
+  case updateLookupHasTableOfContents(_: Bool)
   case docPageLoadURL(_: URL)
   case findInPage(query: String)
   case findPreviousInPage
@@ -103,6 +104,9 @@ public class SceneState: HasDisposeBag {
   private let _lookupSceneTitle = BehaviorRelay<String>(value: "")
   public lazy var lookupSceneTitle: Driver<String> = { _lookupSceneTitle.asDriver() }()
 
+  private let _lookupHasTableOfContents = BehaviorRelay<Bool>(value: false)
+  public lazy var lookupHasTableOfContents: Driver<Bool> = { _lookupHasTableOfContents.asDriver() }()
+
   private let _docPageLoadURL = PublishRelay<URL>()
   public lazy var docPageLoadURL: Signal<URL> = { _docPageLoadURL.asSignal() }()
 
@@ -135,6 +139,8 @@ public class SceneState: HasDisposeBag {
       _docPageCurrentURL.accept(url)
     case let .updateLookupSceneTitle(title):
       _lookupSceneTitle.accept(title)
+    case let .updateLookupHasTableOfContents(value):
+      _lookupHasTableOfContents.accept(value)
     case let .docPageLoadURL(url):
       _docPageLoadURL.accept(url)
     case let .findInPage(query: query):

--- a/BoltFramework/BoltUIFoundation/Extensions/UIKit/UISearchBar+Extensions.swift
+++ b/BoltFramework/BoltUIFoundation/Extensions/UIKit/UISearchBar+Extensions.swift
@@ -1,0 +1,39 @@
+//
+// Copyright (C) 2025 Bolt Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import UIKit
+
+// https://stackoverflow.com/questions/25304989/#25306759
+
+extension UISearchBar {
+
+  public var scopeBar: UISegmentedControl? {
+    return segmentedControl(in: self)
+  }
+
+  private func segmentedControl(in view: UIView) -> UISegmentedControl? {
+    if let segmentedControl = view as? UISegmentedControl {
+      return segmentedControl
+    }
+    for childView in view.subviews {
+      if let segmentedControl = segmentedControl(in: childView) {
+        return segmentedControl
+      }
+    }
+    return nil
+  }
+
+}


### PR DESCRIPTION
* Implement the table of contents button action on the toolbar.
* Pre-fetch table of content entries on page URL change, and show the scope button only when there are any entries.