### PR TITLE
Fix docset name display regressions

### DIFF
--- a/BoltFramework/BoltHomeUI/HomeListViewController.swift
+++ b/BoltFramework/BoltHomeUI/HomeListViewController.swift
@@ -53,7 +53,7 @@ final class HomeListCollectionViewItemCell: UICollectionViewListCell {
       let attributedTitle = NSAttributedString(
         string: viewModel.title ?? "",
         attributes: [
-          .font: UIFont.systemFont(ofSize: 16),
+          .font: UIFont.preferredFont(forTextStyle: .body),
           .paragraphStyle: paragraphStyle,
         ]
       )

--- a/BoltFramework/BoltLibraryUI/Scenes/FeedEntry/LibraryFeedEntryView.swift
+++ b/BoltFramework/BoltLibraryUI/Scenes/FeedEntry/LibraryFeedEntryView.swift
@@ -294,11 +294,10 @@ struct LibraryFeedEntryView: View {
       HStack {
         Label("\(dataSource.entry.feed.displayName)", systemImage: "text.book.closed")
           .labelStyle(ListItemLabelStyle(lineLimit: 2))
-          .modify {
-            if #available(iOS 26, *) {
-              $0.lineHeight(.multiple(factor: 1.1))
-            }
-          }
+          .bolt_lineHeight(
+            factor: 1,
+            systemFontSize: UIFont.labelFontSize
+          )
         Spacer()
         Text(dataSource.versionText)
           .layoutPriority(1)

--- a/BoltFramework/BoltLibraryUI/Scenes/FeedInfo/LibraryFeedInfoView.swift
+++ b/BoltFramework/BoltLibraryUI/Scenes/FeedInfo/LibraryFeedInfoView.swift
@@ -46,11 +46,10 @@ struct LibraryFeedInfoView: View {
             .frame(width: 30, height: 30)
           Text(feed.displayName)
             .lineLimit(2)
-            .modify {
-              if #available(iOS 26, *) {
-                $0.lineHeight(.multiple(factor: 1.1))
-              }
-            }
+            .bolt_lineHeight(
+              factor: 1,
+              systemFontSize: UIFont.labelFontSize
+            )
         }
       }
     }

--- a/BoltFramework/BoltLibraryUI/Scenes/Views/DownloadProgressListItemView.swift
+++ b/BoltFramework/BoltLibraryUI/Scenes/Views/DownloadProgressListItemView.swift
@@ -124,11 +124,10 @@ public struct DownloadProgressListItemView: View {
       VStack(alignment: .leading, spacing: 6) {
         Text(title)
           .lineLimit(2)
-          .modify {
-            if #available(iOS 26, *) {
-              $0.lineHeight(.multiple(factor: 1.1))
-            }
-          }
+          .bolt_lineHeight(
+            factor: 1,
+            systemFontSize: UIFont.labelFontSize
+          )
         switch model.progress {
         case .pending:
           ProgressView()

--- a/BoltFramework/BoltUIFoundation/Components/SwiftUI/Text+LineHeight.swift
+++ b/BoltFramework/BoltUIFoundation/Components/SwiftUI/Text+LineHeight.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (C) 2026 Bolt Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+struct LineHeightModifier: ViewModifier {
+
+  var factor: CGFloat
+  var fontSize: CGFloat
+
+  func body(content: Content) -> some View {
+    let uiFont = UIFont.systemFont(ofSize: fontSize)
+    let lineSpacing = (factor - 1) * uiFont.lineHeight
+    content
+      .font(.system(size: fontSize))
+      .lineSpacing(lineSpacing)
+      .padding(.vertical, (lineSpacing / 2))
+  }
+
+}
+
+public extension View {
+
+  func bolt_lineHeight(factor: CGFloat, systemFontSize fontSize: CGFloat) -> some View {
+    modifier(LineHeightModifier(factor: factor, fontSize: fontSize))
+  }
+
+}


### PR DESCRIPTION
Follow-up to eb2886a.

1. Fix the use of .lineHeight() causes character descenders to be clipped by implementing a custom lineHeight modifier.

2. Use dynamic type size for home list titles.