### PR TITLE
Fix list background color issue with an alternative approach

### DIFF
--- a/BoltFramework/BoltLibraryUI/Scenes/FeedList/CustomFeeds/LibraryCustomFeedListView.swift
+++ b/BoltFramework/BoltLibraryUI/Scenes/FeedList/CustomFeeds/LibraryCustomFeedListView.swift
@@ -137,6 +137,7 @@ struct LibraryCustomFeedListView: View {
       } // if
     } // overlay
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .scrollContentBackground(.hidden)
     .background(Color.systemGroupedBackground)
     .navigationTitle("Library-ImportedFeeds-List-title".boltLocalized)
     .navigationBarTitleDisplayMode(.large)

--- a/BoltFramework/BoltLibraryUI/Scenes/FeedList/LibraryFeedListView.swift
+++ b/BoltFramework/BoltLibraryUI/Scenes/FeedList/LibraryFeedListView.swift
@@ -188,8 +188,9 @@ private struct LibraryFeedListView<Model>: View where Model: LibraryFeedListView
           }
         ) // BoltContentUnavailableView
       } // if
-    } // List
+    } // overlay
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .scrollContentBackground(.hidden)
     .background(Color.systemGroupedBackground)
     .sheet(item: $selectedFeed) { identifiableFeed in
       SheetContainer {


### PR DESCRIPTION
The previous approach can cause navigation title to be obscured when the list is empty. This PR replace it with the use .scrollContentBackground to remove the default list background color.