### PR TITLE
Fix lookup search field text restoration issue on cancel (#96)

### DIFF
--- a/BoltFramework/BoltLookupUI/Scenes/Content/LookupContentViewController.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/Content/LookupContentViewController.swift
@@ -189,6 +189,13 @@ public final class LookupContentViewController: UIViewController, HasDisposeBag 
     .disposed(by: disposeBag)
   }
 
+  public override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+    if presentedViewController == lookupSearchController {
+      lookupSearchController.onDismiss(animated: flag)
+    }
+    super.dismiss(animated: flag, completion: completion)
+  }
+
   // MARK: - Private
 
   private func updateNavigationBarAppearance(

--- a/BoltFramework/BoltLookupUI/Scenes/LookupSearchViewController.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/LookupSearchViewController.swift
@@ -176,6 +176,10 @@ public final class LookupSearchController: UISearchController, HasDisposeBag {
     state.selectSearchScope(.tableOfContents)
   }
 
+  func onDismiss(animated: Bool) {
+    restoreSearchFieldText()
+  }
+
   // MARK: Private
 
   private func scopeBarSetNeedsLayout() {
@@ -265,14 +269,6 @@ extension LookupSearchController: UISearchBarDelegate {
 
   public func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
     preserveSearchFieldText()
-  }
-
-  public func textFieldDidBeginEditing(_ textField: UITextField) {
-    restoreSearchFieldText()
-  }
-
-  public func textFieldDidEndEditing(_ textField: UITextField) {
-    restoreSearchFieldText()
   }
 
 }


### PR DESCRIPTION
Fixes #96.

UISearchController clears the search text and token at before `dismissViewControllerAnimated:completion:` after `vieWillDisappear:`, so we can restore the search text just before this call.

<img width="1200" alt="2026-01-27 15 19 02" src="https://github.com/user-attachments/assets/1ba661bc-5a50-4aa6-b941-569f577f6401" />
