### PR TITLE
Fix double navigation controller on welcome screen

### DIFF
--- a/BoltFramework/BoltFramework/SceneManager.swift
+++ b/BoltFramework/BoltFramework/SceneManager.swift
@@ -37,16 +37,13 @@ private class SecondaryNavigationController: UIViewController {
     didSet {
       managedNavigationController.viewControllers = viewControllers
       if !viewControllers.isEmpty {
-        addChild(managedNavigationController) { childView in
-          view.addSubview(childView)
-          childView.snp.makeConstraints {
-            $0.edges.equalTo(view)
-          }
+        view.addSubview(managedNavigationController.view)
+        managedNavigationController.view.snp.makeConstraints {
+          $0.top.bottom.trailing.equalTo(view)
+          $0.leading.equalTo(view.safeAreaLayoutGuide)
         }
       } else {
-        removeChild(managedNavigationController) { childView in
-          childView.removeFromSuperview()
-        }
+        managedNavigationController.view.removeFromSuperview()
       }
     }
   }


### PR DESCRIPTION
On OS 26, calling addChild(_:) or pinning the child view's top to the  safe area causes an extra UINavigationController to be created, this causes the empty state message to be vertically misaligned.

<img width="1200" alt="Screenshot 2026-02-03 at 23 32 39" src="https://github.com/user-attachments/assets/3c134cc8-faa5-49cc-9728-e8093ce8e9bd" />
