### PR TITLE
Avoid stale docset references in HomeListItemViewModel

### DIFF
--- a/BoltFramework/BoltHomeUI/HomeListItemViewModel.swift
+++ b/BoltFramework/BoltHomeUI/HomeListItemViewModel.swift
@@ -30,27 +30,10 @@ struct HomeListItemViewModel {
   var subTitle: String?
   var image: IdentifiableImage?
 
-  var uuid: UUID {
-    return queryResult.record.uuid
-  }
-
-  var record: LibraryRecord {
-    return queryResult.record
-  }
-
-  var docset: Docset? {
-    switch queryResult {
-    case let .docset(docset):
-      return docset
-    case .broken:
-      return nil
-    }
-  }
-
-  private var queryResult: LibraryInstallationQueryResult
+  var uuid: UUID
 
   init(queryResult: LibraryInstallationQueryResult) {
-    self.queryResult = queryResult
+    uuid = queryResult.record.uuid
     switch queryResult {
     case let .docset(docset):
       title = docset.displayName
@@ -78,8 +61,24 @@ struct HomeListItemViewModel {
     }
   }
 
+  func queryInstallation() -> LibraryInstallationQueryResult? {
+    return libraryDocsetsManager.installedDocsets.first { $0.record.uuid == uuid }
+  }
+
+  func queryDocset() -> Docset? {
+    guard let installation = queryInstallation(), case let .docset(docset) = installation else {
+      return nil
+    }
+    return docset
+  }
+
+  // MARK: - Actions
+
   func deleteItem() {
-    try? libraryDocsetsManager.uninstallDocset(forRecord: queryResult.record)
+    guard let record = libraryDocsetsManager.installedRecords.first(where: { $0.uuid == uuid }) else {
+      return
+    }
+    try? libraryDocsetsManager.uninstallDocset(forRecord: record)
   }
 
 }

--- a/BoltFramework/BoltHomeUI/HomeListViewController.swift
+++ b/BoltFramework/BoltHomeUI/HomeListViewController.swift
@@ -300,7 +300,7 @@ final class HomeListViewController: UIViewController, UICollectionViewDelegate, 
 
   @discardableResult
   private func onGetInfo(viewModel: HomeListItemViewModel?) -> Bool {
-    if let docset = viewModel?.docset {
+    if let docset = viewModel?.queryDocset() {
       BoltHomeNavigator.presentDocsetInfo(docset)
       return true
     }

--- a/BoltFramework/BoltHomeUI/HomeViewController.swift
+++ b/BoltFramework/BoltHomeUI/HomeViewController.swift
@@ -308,7 +308,7 @@ public final class HomeViewController: BaseViewController, SearchBarProvider {
         .compactMap { listModel -> LibraryRecord? in
           switch listModel {
           case let .docset(viewModel):
-            return viewModel.record
+            return viewModel.queryInstallation()?.record
           case .header:
             reportIssue("docset reordering: unexpected listModel type")
             return nil
@@ -385,7 +385,7 @@ public final class HomeViewController: BaseViewController, SearchBarProvider {
               if let item = docsetsSecctionSnapshot.items.first(where: { listModel in
                 switch listModel {
                 case .docset(let viewModel):
-                  return viewModel.docset?.uuid == docset.uuid
+                  return viewModel.uuid == docset.uuid
                 default:
                   return false
                 }
@@ -409,10 +409,11 @@ public final class HomeViewController: BaseViewController, SearchBarProvider {
         case .header:
           break
         case .docset(let viewModel):
-          if let docset = viewModel.docset {
+          let queryResult = viewModel.queryInstallation()
+          switch queryResult {
+          case let .docset(docset):
             owner.sceneState.dispatch(action: .updateCurrentScope(.docset(docset)))
-          } else {
-            let installation = viewModel.record
+          case let .broken(installation):
             GlobalUI.presentAlertController(
               UIAlertController.alert(
                 withTitle: "Home-List-RemoveDamagedDocsetAlert-title".boltLocalized,
@@ -427,6 +428,8 @@ public final class HomeViewController: BaseViewController, SearchBarProvider {
                 cancelAction: (UIKitLocalizations.cancel, nil)
               )
             )
+          case .none:
+            break
           }
         }
       }


### PR DESCRIPTION
Store the UUIDs in home list item view models and re-query the current installation when needed.