### PR TITLE
Eagerly load lookupSearchController.view (#131)

### DIFF
--- a/BoltFramework/BoltLookupUI/Scenes/Content/LookupContentViewController.swift
+++ b/BoltFramework/BoltLookupUI/Scenes/Content/LookupContentViewController.swift
@@ -96,6 +96,8 @@ public final class LookupContentViewController: UIViewController, HasDisposeBag 
       $0.preferredSearchBarPlacement = .stacked
     }
 
+    let _ = lookupSearchController.view
+
     view.addSubview(scopeBar)
     scopeBar.snp.makeConstraints {
       $0.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)


### PR DESCRIPTION
Fixes #131 by eagerly load `lookupSearchController.view`.